### PR TITLE
adding wildcard pre-fix to push-jobs

### DIFF
--- a/recipes/deploy.rb
+++ b/recipes/deploy.rb
@@ -51,7 +51,7 @@ end
 unless search_terms.empty?
   search_query = "(#{search_terms.join(' OR ')}) " \
                  "AND chef_environment:#{delivery_environment} " \
-                 "AND recipes:push-jobs*"
+                 "AND recipes:*push-jobs*"
 
   my_nodes = delivery_chef_server_search(:node, search_query)
 


### PR DESCRIPTION
The deploy recipe will not trigger a deployment against our nodes unless they have the push-jobs recipe. If we cannot use the default push-jobs recipe to manage the push-jobs service (due to organisational requirements) we need to create a wrapper cookbook to enable some customisation. This wrapper cookbook would have a prefix in its name.

Adding this wildcard would enable delivery-truck to trigger deployments using a custom push-jobs without us having to build a custom delivery-truck pipeline as well.