### PR TITLE
Support foodcritic fail tags and fix multiple only rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ which rules you would like to follow directly from your `config.json`.
 * `ignore_rules` - Provide a list of foodcritic rules you would like to ignore.
 * `only_rules` - Explicitly state which foodcritic rules you would like to run.
 Any other rules except these will be ignored.
-* `excludes` - Explicitly state which relative paths foodcritic should ignore
+* `excludes` - Explicitly state which relative paths foodcritic should ignore.
+* `fail_tags` - Explicitly state which rules should cause the run to fail. Defaults
+to `correctness`.
 
 ```json
 {
@@ -42,7 +44,8 @@ Any other rules except these will be ignored.
       "foodcritic": {
         "ignore_rules": ["FC001"],
         "only_rules": ["FC002"],
-        "excludes": ["spec", "test"]
+        "excludes": ["spec", "test"],
+        "fail_tags": ["any"]
       }
     }
   }

--- a/libraries/helpers_lint.rb
+++ b/libraries/helpers_lint.rb
@@ -30,7 +30,7 @@ module DeliveryTruck
           config = node['delivery']['config']['delivery-truck']['lint']['foodcritic']
           case
           when config['only_rules'] && !config['only_rules'].empty?
-            "-t " + config['only_rules'].join(" -t ")
+            "-t " + config['only_rules'].join(",")
           when config['ignore_rules'] && !config['ignore_rules'].empty?
             "-t ~" + config['ignore_rules'].join(" -t ~")
           else
@@ -59,6 +59,23 @@ module DeliveryTruck
           ""
         end
       end
+
+      # Based on the properties in the Delivery Config, create the --epic_fail
+      # (-f) tags that will be passed into the foodcritic command.
+      #
+      # @param node [Chef::Node] Chef Node object
+      # @return [String]
+      def foodcritic_fail_tags(node)
+        config = node['delivery']['config']['delivery-truck']['lint']['foodcritic']
+        case
+        when config['fail_tags'] && !config['fail_tags'].empty?
+          '-f ' + config['fail_tags'].join(',')
+        else
+          '-f correctness'
+        end
+      rescue
+        '-f correctness'
+      end
     end
   end
 
@@ -72,6 +89,11 @@ module DeliveryTruck
     # Return the applicable excludes for foodcritic runs
     def foodcritic_excludes
       DeliveryTruck::Helpers::Lint.foodcritic_excludes(node)
+    end
+
+    # Return the fail tags for foodcritic runs
+    def foodcritic_fail_tags
+      DeliveryTruck::Helpers::Lint.foodcritic_fail_tags(node)
     end
   end
 end

--- a/recipes/lint.rb
+++ b/recipes/lint.rb
@@ -18,7 +18,8 @@
 changed_cookbooks.each do |cookbook|
   # Run Foodcritic against any cookbooks that were modified.
   execute "lint_foodcritic_#{cookbook.name}" do
-    command "foodcritic -f correctness #{foodcritic_tags} #{foodcritic_excludes} #{cookbook.path}"
+    command "foodcritic #{foodcritic_fail_tags} #{foodcritic_tags} " \
+      "#{foodcritic_excludes} #{cookbook.path}"
   end
 
   # Run Rubocop against any cookbooks that were modified.

--- a/spec/unit/libraries/helpers_lint_spec.rb
+++ b/spec/unit/libraries/helpers_lint_spec.rb
@@ -51,7 +51,7 @@ describe DeliveryTruck::Helpers::Lint do
         end
 
         it 'returns a string with multiple rules' do
-          expect(described_class.foodcritic_tags(node)).to eql "-t FC001 -t FC002"
+          expect(described_class.foodcritic_tags(node)).to eql "-t FC001,FC002"
         end
       end
     end
@@ -127,6 +127,38 @@ describe DeliveryTruck::Helpers::Lint do
 
         it 'returns a string with multiple excludes' do
           expect(described_class.foodcritic_excludes(node)).to eql "--exclude spec --exclude test"
+        end
+      end
+    end
+    
+    context 'when `fail_tags` has been set' do
+      context 'with no rules' do
+        before do
+          node.default['delivery']['config']['delivery-truck']['lint']['foodcritic']['fail_tags'] = []
+        end
+
+        it 'returns correctness tag' do
+          expect(described_class.foodcritic_fail_tags(node)).to eql '-f correctness'
+        end
+      end
+
+      context 'with one rule' do
+        before do
+          node.default['delivery']['config']['delivery-truck']['lint']['foodcritic']['fail_tags'] = ['any']
+        end
+
+        it 'returns a string with the one rule' do
+          expect(described_class.foodcritic_fail_tags(node)).to eql '-f any'
+        end
+      end
+
+      context 'with multiple rules' do
+        before do
+          node.default['delivery']['config']['delivery-truck']['lint']['foodcritic']['fail_tags'] = ['correctness', 'metadata']
+        end
+
+        it 'returns a string with multiple rules' do
+          expect(described_class.foodcritic_fail_tags(node)).to eql "-f correctness,metadata"
         end
       end
     end

--- a/spec/unit/recipes/lint_spec.rb
+++ b/spec/unit/recipes/lint_spec.rb
@@ -24,6 +24,7 @@ describe "delivery-truck::lint" do
 
   context "when a single cookbook has been modified" do
     before do
+      allow(DeliveryTruck::Helpers::Lint).to receive(:foodcritic_epic_fail).and_return("-f correctness")
       allow(DeliveryTruck::Helpers::Lint).to receive(:foodcritic_tags).and_return("-t FC001")
       allow(DeliveryTruck::Helpers::Lint).to receive(:foodcritic_excludes).and_return("--exclude spec")
       allow_any_instance_of(Chef::Recipe).to receive(:changed_cookbooks).and_return(one_changed_cookbook)
@@ -40,6 +41,7 @@ describe "delivery-truck::lint" do
 
   context "when multiple cookbooks have been modified" do
     before do
+      allow(DeliveryTruck::Helpers::Lint).to receive(:foodcritic_epic_fail).and_return("-f correctness")
       allow(DeliveryTruck::Helpers::Lint).to receive(:foodcritic_tags).and_return("-t ~FC002")
       allow(DeliveryTruck::Helpers::Lint).to receive(:foodcritic_excludes).and_return("--exclude test")
       allow_any_instance_of(Chef::Recipe).to receive(:changed_cookbooks).and_return(two_changed_cookbooks)
@@ -71,6 +73,7 @@ describe "delivery-truck::lint" do
 
   context "when a .rubocop.yml is present" do
     before do
+      allow(DeliveryTruck::Helpers::Lint).to receive(:foodcritic_epic_fail).and_return("-f correctness")
       allow(DeliveryTruck::Helpers::Lint).to receive(:foodcritic_tags).and_return("")
       allow_any_instance_of(Chef::Recipe).to receive(:changed_cookbooks).and_return(one_changed_cookbook)
       allow(File).to receive(:exist?).and_call_original


### PR DESCRIPTION
Currently lint phase only reports a problem if one of the correctness rules fires. This PR adds a `fail_tags` option to the config.json to make this configurable. For example, `"fail_tags": ["any"]` will report if any rule fails.

The PR also changes `foodcritic_tags` to generate a comma-separated list `-t FC002,FC005` because foodcritic does not correctly handle multiple -t flags like `-t FC002 -t FC005`. Multiple ignore tags like `-t ~FC008 -t ~FC009` works correctly.

Let me know if you need the two things as separate PRs