### PR TITLE
Fix exception copying environments from union to rehearsal

### DIFF
--- a/libraries/helpers_provision.rb
+++ b/libraries/helpers_provision.rb
@@ -346,6 +346,7 @@ module DeliveryTruck
             chef_log.info("Promoting cookbooks and applications for project #{project_name}")
 
             # promote cookbooks
+            project_contents['cookbooks'] ||= {}
             project_contents['cookbooks'].each do |cookbook_name|
               promoted_on_env.cookbook_versions[cookbook_name] =
                 promoted_from_env.cookbook_versions[cookbook_name]
@@ -353,6 +354,7 @@ module DeliveryTruck
 
             promoted_on_env.default_attributes['delivery']['project_artifacts'][project_name] = project_contents
 
+            project_contents['applications'] ||= {}
             project_contents['applications'].each do |app_name|
               promoted_on_env.override_attributes['applications'][app_name] =
                 promoted_from_env.override_attributes['applications'][app_name]

--- a/libraries/helpers_provision.rb
+++ b/libraries/helpers_provision.rb
@@ -346,16 +346,14 @@ module DeliveryTruck
             chef_log.info("Promoting cookbooks and applications for project #{project_name}")
 
             # promote cookbooks
-            project_contents['cookbooks'] ||= {}
-            project_contents['cookbooks'].each do |cookbook_name|
+            (project_contents['cookbooks'] || []).each do |cookbook_name|
               promoted_on_env.cookbook_versions[cookbook_name] =
                 promoted_from_env.cookbook_versions[cookbook_name]
             end
 
             promoted_on_env.default_attributes['delivery']['project_artifacts'][project_name] = project_contents
 
-            project_contents['applications'] ||= {}
-            project_contents['applications'].each do |app_name|
+            (project_contents['applications'] || []).each do |app_name|
               promoted_on_env.override_attributes['applications'][app_name] =
                 promoted_from_env.override_attributes['applications'][app_name]
             end


### PR DESCRIPTION
We started getting exceptions from other projects after using define_project_application on one project when trying to copy environment variables from union to rehearsal where ['delivery']['project_artifacts'] applications where nil in the union environment