### PR TITLE
Add support for cookstyle linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,30 @@ to `correctness`.
 }
 ```
 
+By default, the `lint` phase will run [RuboCop](http://batsov.com/rubocop/), but
+only on cookbooks that have a `.rubocop.yml` file.
+
+You can over-ride this behavior to use [cookstyle](https://github.com/chef/cookstyle)
+instead of RuboCop by enabling it in your `config.json`.
+
+```json
+{
+  "version": "2",
+  "build_cookbook": {
+    "name": "delivery-truck",
+    "git": "https://github.com/chef-cookbooks/delivery-truck.git"
+  },
+  "delivery-truck": {
+    "lint": {
+      "enable_cookstyle": true
+    }
+  }
+}
+```
+
+*Note: To enable cookstyle, your builders/runners must be running ChefDK version
+v0.14 or higher.*
+
 ### publish
 From the `publish` phase you can quickly and easily deploy cookbooks to
 your Chef Server, Supermarket Server and your entire project to a Github account.

--- a/libraries/helpers_lint.rb
+++ b/libraries/helpers_lint.rb
@@ -94,6 +94,17 @@ module DeliveryTruck
       rescue
         '-f correctness'
       end
+      # Read the Delivery Config to see if the user has indicated they want to
+      # run cookstyle tests on their cookbook
+      #
+      # @param [Chef::Node] Chef Node object
+      # @return [TrueClass, FalseClass]
+      def cookstyle_enabled?(node)
+        node['delivery']['config']['delivery-truck']['lint']['enable_cookstyle']
+      rescue
+        false
+      end
+
     end
   end
 
@@ -112,6 +123,11 @@ module DeliveryTruck
     # Return the fail tags for foodcritic runs
     def foodcritic_fail_tags
       DeliveryTruck::Helpers::Lint.foodcritic_fail_tags(node)
+    end
+
+    # Check config.json for whether user wants to share to Supermarket
+    def cookstyle_enabled?
+      DeliveryTruck::Helpers::Lint.cookstyle_enabled?(node)
     end
   end
 end

--- a/recipes/lint.rb
+++ b/recipes/lint.rb
@@ -21,14 +21,28 @@ changed_cookbooks.each do |cookbook|
     command "foodcritic #{foodcritic_fail_tags} #{foodcritic_tags} " \
       "#{foodcritic_excludes} #{cookbook.path}"
   end
-
-  # Run Rubocop against any cookbooks that were modified.
-  execute "lint_rubocop_#{cookbook.name}" do
-    command "rubocop #{cookbook.path}"
-    environment(
-      # workaround for https://github.com/bbatsov/rubocop/issues/2407
-      'USER' => (ENV['USER'] || 'dbuild')
-    )
-    only_if { File.exist?(File.join(cookbook.path, '.rubocop.yml')) }
+  # If cookstyle is enabled in config.json, run cookstyle against any
+  # cookbooks that were modified. Otherwise, run rubocop against any
+  # modified cookbooks, if the cookbook contains a .rubocop.yml file
+  if cookstyle_enabled?
+    execute "lint_cookstyle_#{cookbook.name}" do
+      command "cookstyle #{cookbook.path}"
+      environment(
+        # workaround for https://github.com/bbatsov/rubocop/issues/2407
+        'USER' => (ENV['USER'] || 'dbuild')
+      )
+      live_stream true
+      only_if 'cookstyle -v'
+    end
+  else
+    execute "lint_rubocop_#{cookbook.name}" do
+      command "rubocop #{cookbook.path}"
+      environment(
+        # workaround for https://github.com/bbatsov/rubocop/issues/2407
+        'USER' => (ENV['USER'] || 'dbuild')
+      )
+      live_stream true
+      only_if { File.exist?(File.join(cookbook.path, '.rubocop.yml')) }
+    end
   end
 end


### PR DESCRIPTION
This change supports an opt-in feature in the `lint` stage to use `cookstyle` instead of `rubocop` for linting.

The user will set this using the `enable_cookstyle` configuration setting in `config.json`, which will cause cookstyle tests to be executed against any changed cookbooks.

If `cookstyle` is not available on the builder/runner, these tests will not occur.

This change also updated the README with instructions on how to use this new functionality.

This change also adds the `live_stream` parameter to the `rubocop` tests for more output to the console.

Fixes #24 

Signed-off-by: Matt Stratton <matt.stratton@gmail.com>