### PR TITLE
Add search for recipe to allow deployment on new nodes with new runlists

### DIFF
--- a/recipes/deploy.rb
+++ b/recipes/deploy.rb
@@ -20,6 +20,7 @@
 search_terms = []
 get_all_project_cookbooks.each do |cookbook|
   search_terms << "recipes:#{cookbook.name}*"
+  search_terms << "recipe:#{cookbook.name}*"
 end
 
 unless search_terms.empty?


### PR DESCRIPTION
The deploy recipe now searches for recipes:mycookbook* for all changes to mycookbook. If we also added the search term recipe:mycookbook*, it would work to set the runlist of the node and then run the pipeline. Now I have to manually trigger chef-client once on nodes where run_list has changed.

Particularly this works well with using chef_node cheffish resource to set run_list of existing nodes in provision.rb, and then deploy.rb will deploy them.
