### PR TITLE
Fix a situation where deploys would fail if the workspace is in a non-standard location

### DIFF
--- a/libraries/helpers_deploy.rb
+++ b/libraries/helpers_deploy.rb
@@ -31,9 +31,9 @@ module DeliveryTruck
         'recipes:*push-jobs*'
       end
 
-      def delivery_chef_server_search(type, query)
+      def delivery_chef_server_search(type, query, delivery_knife_rb)
         results = []
-        DeliverySugar::ChefServer.new.with_server_config do
+        DeliverySugar::ChefServer.new(delivery_knife_rb).with_server_config do
           ::Chef::Search::Query.new.search(type, query) { |o| results << o }
         end
         results
@@ -43,7 +43,7 @@ module DeliveryTruck
 
   module DSL
     def delivery_chef_server_search(type, query)
-      DeliveryTruck::Helpers::Deploy.delivery_chef_server_search(type, query)
+      DeliveryTruck::Helpers::Deploy.delivery_chef_server_search(type, query, delivery_knife_rb)
     end
 
     # Check config.json to get deployment search query

--- a/spec/unit/recipes/deploy_spec.rb
+++ b/spec/unit/recipes/deploy_spec.rb
@@ -35,6 +35,9 @@ describe "delivery-truck::deploy" do
     "(#{recipe_list}) AND chef_environment:union AND recipes:*push-jobs*"
   end
   let(:node_list) { [MyFakeNode.new("node1"), MyFakeNode.new("node2")] }
+  let(:delivery_knife_rb) do
+    "/var/opt/delivery/workspace/.chef/knife.rb"
+  end
 
   context "when a single cookbook has been modified" do
     before do
@@ -45,7 +48,7 @@ describe "delivery-truck::deploy" do
     let(:recipe_list) { 'recipes:julia*' }
 
     it "deploy only that cookbook" do
-      expect(DeliveryTruck::Helpers::Deploy).to receive(:delivery_chef_server_search).with(:node, search_query).and_return(node_list)
+      expect(DeliveryTruck::Helpers::Deploy).to receive(:delivery_chef_server_search).with(:node, search_query, delivery_knife_rb).and_return(node_list)
       expect(chef_run).to dispatch_delivery_push_job("deploy_Secret").with(
                             :command => 'chef-client',
                             :nodes => node_list
@@ -62,7 +65,7 @@ describe "delivery-truck::deploy" do
       end
       it "deploy only that cookbook with the special search query" do
         expect(DeliveryTruck::Helpers::Deploy).to receive(:delivery_chef_server_search)
-          .with(:node, search_query)
+          .with(:node, search_query, delivery_knife_rb)
           .and_return(node_list)
         expect(chef_run).to dispatch_delivery_push_job("deploy_Secret").with(
                               :command => 'chef-client',


### PR DESCRIPTION
The `DeliverySugar::ChefServer` class expects a node object to exist in order for it to look up the `delivery_knife_rb` ( [here](https://github.com/chef-cookbooks/delivery-sugar/blob/master/libraries/delivery_chef_server.rb#L39) ) , but that doesn't exist the way it's being called from `DeliveryTruck::Helpers::Deploy`. 

This PR calls the same `delivery_knife_rb` method from [DeliverySugar::DSL](https://github.com/chef-cookbooks/delivery-sugar/blob/master/libraries/delivery_dsl.rb#L26) but in a way that it can succeed by calling it from the DSL method and then passing it to the non-DSL method.

As a point of discussion:
1.  The `rescue` in `DeliverySugar::DSL.delivery_workspace` ( [link](https://github.com/chef-cookbooks/delivery-sugar/blob/master/libraries/delivery_dsl.rb#L38) ) seems like a bad idea, because it's masking a problem where the node object doesn't exist, causing the `change` method to blow up.   That should be revisited, I suspect that this is a problem for any customer that uses a non-standard workspace location.

2. It's not clear to me why the `DeliveryTruck::Helpers::DSL.delivery_chef_server_search` method needs to alias `DeliveryTruck::Helpers::Deploy.delivery_chef_server_search` ( [link](https://github.com/chef-cookbooks/delivery-truck/blob/master/libraries/helpers_deploy.rb#L45) ) -  it would be helpful if someone with some history could explain that.