### PR TITLE
Add resources to bumped version helper

### DIFF
--- a/libraries/helpers_syntax.rb
+++ b/libraries/helpers_syntax.rb
@@ -53,13 +53,13 @@ module DeliveryTruck
           Berksfile\.lock
           Policyfile\.rb
           Policyfile\.lock\.json
+          attributes\/.*
+          definitions\/.*
+          files\/.*
+          libraries\/.*
+          providers\/.*
           recipes\/.*
           resources\/.*
-          providers\/.*
-          definitions\/.*
-          attributes\/.*
-          libraries\/.*
-          files\/.*
           templates\/.*
         ).join('|')
 

--- a/libraries/helpers_syntax.rb
+++ b/libraries/helpers_syntax.rb
@@ -54,6 +54,9 @@ module DeliveryTruck
           Policyfile\.rb
           Policyfile\.lock\.json
           recipes\/.*
+          resources\/.*
+          providers\/.*
+          definitions\/.*
           attributes\/.*
           libraries\/.*
           files\/.*

--- a/recipes/syntax.rb
+++ b/recipes/syntax.rb
@@ -29,6 +29,9 @@ The version must be updated when any of the following files are modified:
    Policyfile.rb
    Policyfile.lock.json
    recipes/.*
+   resources/.*
+   providers/.*
+   definitions/.*
    attributes/.*
    libraries/.*
    files/.*

--- a/recipes/syntax.rb
+++ b/recipes/syntax.rb
@@ -28,13 +28,13 @@ The version must be updated when any of the following files are modified:
    Berksfile.lock
    Policyfile.rb
    Policyfile.lock.json
+   attributes/.*
+   definitions/.*
+   files/.*
+   libraries/.*
+   providers/.*
    recipes/.*
    resources/.*
-   providers/.*
-   definitions/.*
-   attributes/.*
-   libraries/.*
-   files/.*
    templates/.*}
   end
 


### PR DESCRIPTION
Adds `resources`, `providers` and `definitions` directory to the `bumped_version?` helper

Fixes #40.